### PR TITLE
Issue 2 goToNextPage fix

### DIFF
--- a/src/koco-list-base-viewmodel.js
+++ b/src/koco-list-base-viewmodel.js
@@ -195,7 +195,7 @@ define([
 
             self.updateSearchArgumentsWithPagingArguments();
 
-            return self.search();
+            return self.searchWithFilters();
         };
 
         ContentListBaseViewModel.prototype.updateOrderBy = function(newOrderBy) {


### PR DESCRIPTION
return searchWithFilters() instead of search() so that paging will use the current search arguments

fix for #2 
